### PR TITLE
add/plan_details

### DIFF
--- a/app/controllers/public/plans_controller.rb
+++ b/app/controllers/public/plans_controller.rb
@@ -7,6 +7,10 @@ class Public::PlansController < ApplicationController
     @plan.plan_details.build
   end
 
+  def index
+    @plans = Plan.all
+  end
+
   def show
     @plan_details = @plan.plan_details
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,11 +18,11 @@ Turbolinks.start()
 ActiveStorage.start()
 
 $(document).ready(function() {
-  var wrapper = $('#plan_details_wrapper');
-  var addButton = $('#add_plan_details');
+  var wrapper = '#plan_details_wrapper';
+  var addButton = '#add_plan_details';
   var x = 0;
 
-  $(addButton).click(function(e) {
+  $(document).on("click", addButton, function(e) {
     e.preventDefault();
     x++;
 
@@ -39,7 +39,7 @@ $(document).ready(function() {
     $(wrapper).append(formHtml);
   });
 
-  $(wrapper).on("click", ".remove_field", function(e) {
+  $(document).on("click", wrapper + " .remove_field", function(e) {
     e.preventDefault();
     $(this).parent('div').remove();
     x--;

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,10 +2,7 @@
 
   <% if user_signed_in? %>
   <li>
-    <%= link_to "投稿一覧", "#" %>
-  </li>
-  <li>
-    <%= link_to "検索","#" %>
+    <%= link_to "投稿一覧", plans_path %>
   </li>
   <li>
     <%= link_to "投稿",new_plan_path %>
@@ -16,10 +13,7 @@
 
   <% else %>
   <li>
-    <%= link_to "投稿一覧", "#" %>
-  </li>
-  <li>
-    <%= link_to "検索","#" %>
+    <%= link_to "投稿一覧", plans_path %>
   </li>
   <% end %>
 

--- a/app/views/public/plans/edit.html.erb
+++ b/app/views/public/plans/edit.html.erb
@@ -8,6 +8,14 @@
   <%= f.label :本文 %>
   <%= f.text_field :body %>
 
+  <%= f.fields_for :plan_details do |f| %>
+    <%= f.label :タイトル %>
+    <%= f.text_field :title %>
+
+    <%= f.label :本文 %>
+    <%= f.text_field :body %>
+  <% end %>
+
   <%= f.submit "編集を保存" %>
 
 <% end %>

--- a/app/views/public/plans/index.html.erb
+++ b/app/views/public/plans/index.html.erb
@@ -1,0 +1,6 @@
+<h1>投稿一覧</h1>
+
+<% @plans.each do |plan| %>
+  <%= link_to plan.title, plan_path(plan) %>
+  <%= plan.body %>
+<% end %>


### PR DESCRIPTION
プラン、プラン詳細の機能追加
・プラン一覧作成
・プラン編集画面で、詳細の編集もできるよう追加

プラン作成フォームで、リロードしないとプラン詳細フォームを追加できなかったので、
JavaScriptコード修正