### PR TITLE
Fix/like chatroom

### DIFF
--- a/app/controllers/public/plans_controller.rb
+++ b/app/controllers/public/plans_controller.rb
@@ -1,6 +1,6 @@
 class Public::PlansController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_plan, only: [:show, :edit, :update, :destroy]
+  before_action :set_plan, only: [:show, :edit, :update, :destroy, :liked_users]
   before_action :user_is_active, only: [:show]
   before_action :ensure_current_user, only: [:edit, :update, :destroy]
 
@@ -90,6 +90,10 @@ class Public::PlansController < ApplicationController
     @tag_list = Tag.all
     @tag = Tag.find(params[:tag_id])
     @plans = @tag.plans
+  end
+
+  def liked_users
+    @liked_users = @plan.liked_users
   end
 
   private

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -9,6 +9,7 @@ class Plan < ApplicationRecord
   has_many :tags, through: :plan_tags
   has_many :notifications, as: :subject, dependent: :destroy
   has_many :view_counts, dependent: :destroy
+  has_many :liked_users, through: :likes, source: :user
 
   # 子モデル（plan_details）の属性を受入れ、更新や削除を許可する
   accepts_nested_attributes_for :plan_details, allow_destroy: true

--- a/app/views/public/chats/_form.html.erb
+++ b/app/views/public/chats/_form.html.erb
@@ -5,7 +5,7 @@
         <%= form_with model: chat, local: false do |f| %>
           <div class="input-group">
             <%= f.hidden_field :room_id %>
-            <%= f.text_field :message, class: "form-control chat_textfield", placeholder: "コメントを送信" %>
+            <%= f.text_area :message, class: "form-control chat_textfield", placeholder: "コメントを送信", rows: 1 %>
             <div class="input-group-append">
               <button type="submit" class="btn btn-primary">
                 <i class="fas fa-paper-plane fa-lg" style="color: #ffffff;"></i>

--- a/app/views/public/chats/index.html.erb
+++ b/app/views/public/chats/index.html.erb
@@ -2,16 +2,22 @@
   <div class="row">
     <div class="col-sm-12 col-md-10 col-lg-8 my-3 p-4 mx-auto">
 
-      <% @user_rooms.each do |user_room| %>
-        <% room = user_room[:room] %>
-        <% other_user = user_room[:other_user] %>
-        <div class="row mb-3 bg-light p-3 rounded">
-          <div class="col">
-            <%= image_tag other_user.get_profile_image(90, 90), class: "rounded-circle mx-auto d-block" %>
+      <% if @user_rooms.present? %>
+        <% @user_rooms.each do |user_room| %>
+          <% room = user_room[:room] %>
+          <% other_user = user_room[:other_user] %>
+          <div class="row mb-3 bg-light p-3 rounded">
+            <div class="col">
+              <%= image_tag other_user.get_profile_image(90, 90), class: "rounded-circle mx-auto d-block" %>
+            </div>
+            <div class="col d-flex align-items-center">
+              <%= link_to other_user.name, chat_path(other_user), class: 'text-decoration-none' %>
+            </div>
           </div>
-          <div class="col d-flex align-items-center">
-            <%= link_to other_user.name, chat_path(other_user), class: 'text-decoration-none' %>
-          </div>
+        <% end %>
+      <% else %>
+        <div class="text-center mt-5">
+          チャットルームがありません
         </div>
       <% end %>
 

--- a/app/views/public/chats/show.html.erb
+++ b/app/views/public/chats/show.html.erb
@@ -1,13 +1,15 @@
 <div class="container">
   <div class="row">
     <div class="col-sm-12 col-md-10 col-lg-8 my-3 p-4 mx-auto">
-      <div class="text-center">
-        <%= image_tag @user.get_profile_image(90, 90), class: "rounded-circle mx-auto d-block" %>
-        <%= @user.name %>
+      <div class="text-center mb-3">
+        <%= link_to user_path(@user), class: "text-decoration-none" do %>
+          <%= image_tag @user.get_profile_image(90, 90), class: "rounded-circle mx-auto d-block" %>
+          <%= @user.name %>
+        <% end %>
       </div>
 
       <!-- チャット一覧テンプレート -->
-      <div class="row chat-index mx-auto">
+      <div class="chat-index">
         <%= render 'public/chats/chats', chats: @chats %>
       </div>
 

--- a/app/views/public/likes/_like.html.erb
+++ b/app/views/public/likes/_like.html.erb
@@ -2,14 +2,16 @@
 
   <% if plan.liked_by?(current_user) %>
     <%= link_to plan_like_path(plan), method: :delete, remote: true do %>
-      <i class="fa-solid fa-star fa-lg" style="color: #FFD43B;"></i><%= plan.likes.count %>
+      <i class="fa-solid fa-star fa-lg" style="color: #FFD43B;"></i>
     <% end %>
+    <%= link_to plan.likes.count, liked_users_plan_path(plan) %>
   <% else %>
     <%= link_to plan_like_path(plan), method: :post, remote: true do %>
-      <i class="fa-regular fa-star fa-lg" style="color: #3b4674;"></i><%= plan.likes.count %>
+      <i class="fa-regular fa-star fa-lg" style="color: #3b4674;"></i>
     <% end %>
+    <%= link_to plan.likes.count, liked_users_plan_path(plan) %>
   <% end %>
 
 <% else %>
-  <i class="fa-regular fa-star fa-lg" style="color: #3b4674;"></i><%= plan.likes.count %>
+  <i class="fa-regular fa-star fa-lg" style="color: #3b4674;"></i> <%= plan.likes.count %>
 <% end %>

--- a/app/views/public/plans/liked_users.html.erb
+++ b/app/views/public/plans/liked_users.html.erb
@@ -1,7 +1,2 @@
-<% if @liked_users.present? %>
-  <%= render 'public/users/index', users: @liked_users %>
-<% else %>
-  <div class="text-center mt-5">
-    いいねしたユーザーがいません
-  </div>
-<% end %>
+<!--ユーザー一覧-->
+<%= render 'public/users/index', users: @liked_users %>

--- a/app/views/public/plans/liked_users.html.erb
+++ b/app/views/public/plans/liked_users.html.erb
@@ -1,0 +1,7 @@
+<% if @liked_users.present? %>
+  <%= render 'public/users/index', users: @liked_users %>
+<% else %>
+  <div class="text-center mt-5">
+    いいねしたユーザーがいません
+  </div>
+<% end %>

--- a/app/views/public/users/_index.html.erb
+++ b/app/views/public/users/_index.html.erb
@@ -1,4 +1,5 @@
-<% users.each do |user| %>
+<% if users.present? %>
+  <% users.each do |user| %>
 
     <div class="col-sm-8 col-md-6 col-lg-4 bg-white my-3 p-4 mx-auto rounded-pill">
       <div class="row">
@@ -19,4 +20,9 @@
       </div>
     </div>
 
+  <% end %>
+<% else %>
+  <div class="text-center mt-5">
+    ユーザーがいません
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
     resources :plans do
       resources :comments, only: [:create, :destroy]
       resource :like, only: [:create, :destroy]
+      member do
+        get :liked_users
+      end
     end
     get 'search' => 'searches#search'
     get "search_tag" => "plans#search_tag"


### PR DESCRIPTION
チャットルーム
・ユーザーがいない時の表示を修正
・送信フォームのplaceholderを修正（メッセージを送信）
・一つ目のメッセージの位置調整
・ユーザーのアイコンまたはユーザー名をクリックするとユーザー詳細に遷移

いいね数をクリックするといいねしたユーザー一覧を表示